### PR TITLE
Fix: URGENT - Resources and earnings calc updated

### DIFF
--- a/src/pages/api/score/[pbk].ts
+++ b/src/pages/api/score/[pbk].ts
@@ -107,51 +107,92 @@ export default async (
       millisecondsToBurnOneToolkit: account.millisecondsToBurnOneToolkit,
       /* Custom values */
       dailyFuelConsumption: resDailyConsumption(
-        account.millisecondsToBurnOneFuel
+        account.millisecondsToBurnOneFuel,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyFoodConsumption: resDailyConsumption(
-        account.millisecondsToBurnOneFood
+        account.millisecondsToBurnOneFood,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyArmsConsumption: resDailyConsumption(
-        account.millisecondsToBurnOneArms
+        account.millisecondsToBurnOneArms,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyToolkitConsumption: resDailyConsumption(
-        account.millisecondsToBurnOneToolkit
+        account.millisecondsToBurnOneToolkit,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyFuelCostInAtlas: resDailyCostInAtlas(
         FUEL_PRICE,
-        account.millisecondsToBurnOneFuel
+        account.millisecondsToBurnOneFuel,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyFoodCostInAtlas: resDailyCostInAtlas(
         FOOD_PRICE,
-        account.millisecondsToBurnOneFood
+        account.millisecondsToBurnOneFood,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyArmsCostInAtlas: resDailyCostInAtlas(
         ARMS_PRICE,
-        account.millisecondsToBurnOneArms
+        account.millisecondsToBurnOneArms,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyToolkitCostInAtlas: resDailyCostInAtlas(
         TOOLKIT_PRICE,
-        account.millisecondsToBurnOneToolkit
+        account.millisecondsToBurnOneToolkit,
+        account.shipQuantityInEscrow.toNumber()
       ),
       dailyMaintenanceCostInAtlas: dailyMaintenanceCostInAtlas(
-        resDailyCostInAtlas(FUEL_PRICE, account.millisecondsToBurnOneFuel),
-        resDailyCostInAtlas(FOOD_PRICE, account.millisecondsToBurnOneFood),
-        resDailyCostInAtlas(ARMS_PRICE, account.millisecondsToBurnOneArms),
-        resDailyCostInAtlas(TOOLKIT_PRICE, account.millisecondsToBurnOneToolkit)
+        resDailyCostInAtlas(
+          FUEL_PRICE,
+          account.millisecondsToBurnOneFuel,
+          account.shipQuantityInEscrow.toNumber()
+        ),
+        resDailyCostInAtlas(
+          FOOD_PRICE,
+          account.millisecondsToBurnOneFood,
+          account.shipQuantityInEscrow.toNumber()
+        ),
+        resDailyCostInAtlas(
+          ARMS_PRICE,
+          account.millisecondsToBurnOneArms,
+          account.shipQuantityInEscrow.toNumber()
+        ),
+        resDailyCostInAtlas(
+          TOOLKIT_PRICE,
+          account.millisecondsToBurnOneToolkit,
+          account.shipQuantityInEscrow.toNumber()
+        )
       ),
       grossDailyRewardInAtlas: grossDailyRewardInAtlas(
-        account.rewardRatePerSecond.toNumber()
+        account.rewardRatePerSecond.toNumber(),
+        account.shipQuantityInEscrow.toNumber()
       ),
       netDailyRewardInAtlas: netDailyRewardInAtlas(
-        grossDailyRewardInAtlas(account.rewardRatePerSecond.toNumber()),
+        grossDailyRewardInAtlas(
+          account.rewardRatePerSecond.toNumber(),
+          account.shipQuantityInEscrow.toNumber()
+        ),
         dailyMaintenanceCostInAtlas(
-          resDailyCostInAtlas(FUEL_PRICE, account.millisecondsToBurnOneFuel),
-          resDailyCostInAtlas(FOOD_PRICE, account.millisecondsToBurnOneFood),
-          resDailyCostInAtlas(ARMS_PRICE, account.millisecondsToBurnOneArms),
+          resDailyCostInAtlas(
+            FUEL_PRICE,
+            account.millisecondsToBurnOneFuel,
+            account.shipQuantityInEscrow.toNumber()
+          ),
+          resDailyCostInAtlas(
+            FOOD_PRICE,
+            account.millisecondsToBurnOneFood,
+            account.shipQuantityInEscrow.toNumber()
+          ),
+          resDailyCostInAtlas(
+            ARMS_PRICE,
+            account.millisecondsToBurnOneArms,
+            account.shipQuantityInEscrow.toNumber()
+          ),
           resDailyCostInAtlas(
             TOOLKIT_PRICE,
-            account.millisecondsToBurnOneToolkit
+            account.millisecondsToBurnOneToolkit,
+            account.shipQuantityInEscrow.toNumber()
           )
         )
       ),

--- a/src/utils/grossDailyRewardInAtlas/index.ts
+++ b/src/utils/grossDailyRewardInAtlas/index.ts
@@ -1,9 +1,14 @@
 import { ATLAS_DECIMAL } from "~/common/constants";
 
-export const grossDailyRewardInAtlas = (rewardRatePerSecond: number) => {
+export const grossDailyRewardInAtlas = (
+  rewardRatePerSecond: number,
+  shipQuantityInEscrow: number
+) => {
   return (
-    Math.round(
+    (Math.round(
       (rewardRatePerSecond / ATLAS_DECIMAL) * 60 * 60 * 24 * ATLAS_DECIMAL
-    ) / ATLAS_DECIMAL
+    ) /
+      ATLAS_DECIMAL) *
+    shipQuantityInEscrow
   );
 };

--- a/src/utils/resDailyConsumption/index.ts
+++ b/src/utils/resDailyConsumption/index.ts
@@ -1,5 +1,8 @@
 import { ONE_DAY_IN_MILLISECONDS } from "~/common/constants";
 
-export const resDailyConsumption = (burnRate: number) => {
-  return Math.round(ONE_DAY_IN_MILLISECONDS / burnRate);
+export const resDailyConsumption = (
+  burnRate: number,
+  shipQuantityInEscrow: number
+) => {
+  return Math.round(ONE_DAY_IN_MILLISECONDS / burnRate) * shipQuantityInEscrow;
 };

--- a/src/utils/resDailyCostInAtlas/index.ts
+++ b/src/utils/resDailyCostInAtlas/index.ts
@@ -2,11 +2,14 @@ import { ATLAS_DECIMAL, ONE_DAY_IN_MILLISECONDS } from "~/common/constants";
 
 export const resDailyCostInAtlas = (
   resourcePrice: number,
-  burnRate: number
+  burnRate: number,
+  shipQuantityInEscrow: number
 ) => {
   return (
-    Math.round(
+    (Math.round(
       (ONE_DAY_IN_MILLISECONDS / burnRate) * resourcePrice * ATLAS_DECIMAL
-    ) / ATLAS_DECIMAL
+    ) /
+      ATLAS_DECIMAL) *
+    shipQuantityInEscrow
   );
 };


### PR DESCRIPTION
Issue fixed: the calculation of resources, maintenance and net earnings by ship type was for a single ship, even if there was more than one in staking.